### PR TITLE
(Hacky) fix for #46

### DIFF
--- a/content_scripts/fill-username-and-password.js
+++ b/content_scripts/fill-username-and-password.js
@@ -58,6 +58,7 @@ browser.runtime.onMessage.addListener(function _func(request, sender, sendRespon
             passwordField.value = request.password;
             passwordField.dispatchEvent(event);
         }
+        browser.runtime.onMessage.removeListener(_func);
     }
 });
 


### PR DESCRIPTION
This doesn't prevent the content script to be injected multiple times, but it solves the behaviour.

There isn't any way to remove a content script from a page. Another solution would be to keep track if we already injected the content-script but IMO this less hacky.