### PR TITLE
Send input event after filling a input field fixes #74

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,7 +62,8 @@
     "no-alert": "off",
     "no-constant-condition": "off",
     "no-invalid-this": "off",
-    "no-bitwise": "off"
+    "no-bitwise": "off",
+    "space-before-function-paren": "off"
   },
   "globals": {
     "cryptoHelpers": true,

--- a/content_scripts/fill-username-and-password.js
+++ b/content_scripts/fill-username-and-password.js
@@ -76,7 +76,7 @@ browser.runtime.onMessage.addListener(function _func (request, sender, sendRespo
 
     if (passwordField === null && !request.suppress_error_on_missing_pw_field) {
       browser.runtime.sendMessage({'type': 'no-password-field-found'});
-    } else {
+    } else if (passwordField !== null) {
       writeValueToInputElement(passwordField, request.password);
     }
   } else if (request.type === 'username') {


### PR DESCRIPTION
Some websites use a JS framework like React which interact with the
input field in a different matter than plain
HTML. Therefore after filling we send the 'input' event to the
input field so these frameworks now the contents
of the input field has changed.

