### PR TITLE
Fix regression caused by #70

### DIFF
--- a/background/init.js
+++ b/background/init.js
@@ -46,8 +46,7 @@ function init () {
         });
       }
     }).
-      catch(function (err) {
-        console.log(err);
+      catch(function (ss) {
         console.log('Failed to initialize Secure Storage, not associating with keepass!');
         browser.notifications.create({
           'type': 'basic',
@@ -55,6 +54,7 @@ function init () {
           'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
           'title': 'Keywi'
         });
+        Keepass.setSecureStorage(ss);
       });
   });
 }


### PR DESCRIPTION
Steps to reproduce:
 1. install and setup Keywi
 2. restart Firefox
 3. cancel unlock dialog
 4. try to fill in password

Expected result:
Password is filled

Actual result:
Nothing happens, because Keepass._ss is undefined

Signed-off-by: Tobia De Koninck <tobia@ledfan.be>