### PR TITLE
Add btn to associate when not associated + fix bugs in options data

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -179,6 +179,10 @@
     "message": "Reset all settings",
     "description": "options page: reset all settings"
   },
+  "optAssociate": {
+    "message": "Associate with Keepass",
+    "description": "options page: text showed on button to associate with Keepass, if not already associated"
+  },
   "initSSFailed": {
     "message": "Failed to initialize Secure Storage!",
     "description": "Message shown when the secure storage can't be initialized"

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -182,5 +182,9 @@
   "initSSFailed": {
     "message": "De Secure Storage kon niet geïnitialiseerd worden.",
     "description": "Message shown when the secure storage can't be initialized"
+  },
+  "optAssociate": {
+    "message": "Associeer met Keepass",
+    "description": "options page: text showed on button to associate with Keepass, if not already associated"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -182,5 +182,9 @@
   "initSSFailed": {
     "message": "初始化 Secure Storage 失败！",
     "description": "Message shown when the secure storage can't be initialized"
+  },
+  "optAssociate": {
+    "message": "Associate with Keepass",
+    "description": "options page: text showed on button to associate with Keepass, if not already associated"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -184,7 +184,7 @@
     "description": "Message shown when the secure storage can't be initialized"
   },
   "optAssociate": {
-    "message": "Associate with Keepass",
+    "message": "与 KeePass 建立关联",
     "description": "options page: text showed on button to associate with Keepass, if not already associated"
   }
 }

--- a/background/keepass.js
+++ b/background/keepass.js
@@ -360,7 +360,6 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     Keepass._ss.reencrypt(function () {
       sendResponse();
     });
-    return true;
   } else if (request.type === 'reset') {
     Keepass._ss.clear().then(function () {
       return Keepass._ss.reInitialize();
@@ -373,7 +372,6 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       catch(function () {
         sendResponse();
       });
-    return true;
   } else if (request.type === 'options_user_info') {
     let hash = null;
     if (Keepass._ss.ready()) {
@@ -417,10 +415,10 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
             sendResponse(response);
           });
     }
-    return true; // http://stackoverflow.com/a/40773823
   } else if (request.type === 'associate')   {
     Keepass.associate(function () {
       sendResponse();
     });
   }
+  return true; // http://stackoverflow.com/a/40773823
 });

--- a/background/keepass.js
+++ b/background/keepass.js
@@ -378,19 +378,20 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       // if Secure Storage is unlocked
       Keepass._ss.get('database.hash').then(function (data) {
         hash = data;
-        Keepass._ss.get('database.id').then(function (id) {
+        return Keepass._ss.get('database.id');
+      }).
+        then(function (id) {
           // if database id and hash are available we are associated with Keepass
-          const response = {table: {}, associated: true};
+          const response = {'table': {}, 'associated': true};
           response.table[browser.i18n.getMessage('statusSSunlocked')] = true;
           response.table[browser.i18n.getMessage('statusDBassoc')] = true;
           response.table[browser.i18n.getMessage('statusDBhash')] = hash;
           response.table[browser.i18n.getMessage('statusDBid')] = id;
           sendResponse(response);
-        });
-      }).
+        }).
         catch(function () {
           // database id or hash are not available we are not associated with Keepass
-          const response = {table: {}, associated: false};
+          const response = {'table': {}, 'associated': false};
           response.table[browser.i18n.getMessage('statusSSunlocked')] = true;
           response.table[browser.i18n.getMessage('statusDBassoc')] = false;
           sendResponse(response);
@@ -400,22 +401,23 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       Keepass._ss.has('database.hash').then(function (data) {
         hash = data;
         return Keepass._ss.has('database.id');
-      }).then(function (id) {
+      }).
+        then(function (id) {
           // hash and id are available
-          const response = {table: {}, associated: true};
+          const response = {'table': {}, 'associated': true};
           response.table[browser.i18n.getMessage('statusSSunlocked')] = false;
           response.table[browser.i18n.getMessage('statusDBassoc')] = true;
           sendResponse(response);
         }).
-          catch(function () {
+        catch(function () {
           // hash or id are not available
-            const response = {table: {}, associated: false};
-            response.table[browser.i18n.getMessage('statusSSunlocked')] = false;
-            response.table[browser.i18n.getMessage('statusDBassoc')] = false;
-            sendResponse(response);
-          });
+          const response = {'table': {}, 'associated': false};
+          response.table[browser.i18n.getMessage('statusSSunlocked')] = false;
+          response.table[browser.i18n.getMessage('statusDBassoc')] = false;
+          sendResponse(response);
+        });
     }
-  } else if (request.type === 'associate')   {
+  } else if (request.type === 'associate') {
     Keepass.associate(function () {
       sendResponse();
     });

--- a/options/options.html
+++ b/options/options.html
@@ -45,8 +45,10 @@
                 <input type="checkbox" name="defer_unlock_ss" id="defer_unlock_ss" />
                 <label for="defer_unlock_ss" data-i18n="optDeferUnlockSS"></label>
             </fieldset>
-            <button id="btn-re-encrypt" data-i18n="optReEncrypt"></button>
-            <button id="btn-reset" data-i18n="optReset"></button>
+            <br>
+            <button id="btn-re-encrypt" data-i18n="optReEncrypt"></button><br>
+            <button id="btn-reset" data-i18n="optReset"></button><br>
+            <button id="btn-associate" data-i18n="optAssociate"></button>
         </div>
         <script src="options.js"></script>
         <script src="../vendor/debounce.js"></script>

--- a/options/options.js
+++ b/options/options.js
@@ -24,10 +24,17 @@ function readAndUpdateUserInfo () {
     for (let i = 0; i < length; i++) {
       table.deleteRow(0);
     }
-    for (const key of Object.keys(data)) {
+    for (const key of Object.keys(data.table)) {
       const row = table.insertRow(table.rows.length);
       row.insertCell(0).innerText = key;
-      row.insertCell(1).innerText = data[key];
+      row.insertCell(1).innerText = data.table[key];
+    }
+
+    if (data.associated === true) {
+      document.getElementById('btn-associate').style.display = 'none';
+    } else {
+      // just to be sure when the function is called after the user updates.
+      document.getElementById('btn-associate').style.display = 'block';
     }
   });
 }
@@ -74,6 +81,13 @@ window.addEventListener('DOMContentLoaded', function () {
       alert(`To completely disconnect keepass, you will have to remove the key with id "${window.userInfoData['Keepass database id']}" in Keepass!`);
     }
     browser.runtime.sendMessage({'type': 'reset'}).
+      then(function () {
+        readAndUpdateUserInfo();
+      });
+  });
+
+  document.getElementById('btn-associate').addEventListener('click', function () {
+    browser.runtime.sendMessage({'type': 'associate'}).
       then(function () {
         readAndUpdateUserInfo();
       });


### PR DESCRIPTION
Before this fix when you setup the Secure Storage but didn't associated with Keepass (i.e. you cancel the Keepass popup, your database is locked etc) there was no way to only associate without restoring all settings.

I also fixed the overview with data in the options, since this was inaccurate.