### PR TITLE
Remove any elements above input fields to fix cm 

### DIFF
--- a/content_scripts/fix-contentEditable.js
+++ b/content_scripts/fix-contentEditable.js
@@ -35,3 +35,20 @@ fixContentEditable();
  * Some websites dynamically add elements to the DOM.
  */
 document.addEventListener("contextmenu", fixContentEditable, true);
+setTimeout(function() {
+  let inputElements = document.getElementsByTagName('INPUT');
+  for (let inputEl of inputElements) {
+    if (inputEl.type !== "hidden" && inputEl.type !== "submit" && inputEl.type !== "button") {
+      let pos = inputEl.getBoundingClientRect();
+      let topElUnderInput = document.elementFromPoint(pos.x + 2, pos.y + 2);
+      if (topElUnderInput.tagName !== 'INPUT') {
+        // the top most element at the position of the input field isn't the input field itself ...
+        while (topElUnderInput.tagName !== 'INPUT') {
+          // ... remove click events from it and continue until we reached the input event
+          topElUnderInput.style['pointer-events'] = "none";
+          topElUnderInput = document.elementFromPoint(pos.x + 2, pos.y + 2);
+        }
+      }
+    }
+  }
+}, 200);

--- a/content_scripts/fix-contextmenu.js
+++ b/content_scripts/fix-contextmenu.js
@@ -48,8 +48,8 @@ document.addEventListener("contextmenu", fixContentEditable, true);
       let pos = inputEl.getBoundingClientRect();
       // noticed that sometimes the overlapping element is a little below the actual input field
       // so make sure we are actually above an overlapping element
-      let posX = pos.x + 2;
-      let posY = pos.y + 2;
+      let posX = pos.x + pos.width / 2;
+      let posY = pos.y + pos.height / 2;
       let topElUnderInput = document.elementFromPoint(posX, posY);
       if (topElUnderInput.tagName !== 'INPUT') {
         // the top most element at the position of the input field isn't the input field itself ...

--- a/content_scripts/fix-contextmenu.js
+++ b/content_scripts/fix-contextmenu.js
@@ -35,20 +35,32 @@ fixContentEditable();
  * Some websites dynamically add elements to the DOM.
  */
 document.addEventListener("contextmenu", fixContentEditable, true);
-setTimeout(function() {
+
+
+/**
+ * Some websites are using a custom placeholder instead of the HTML5 placeholder attribute. They dot his by creating a
+ * overlapping div on the input field. To fix this we remove the click events from the overlapping input fields.
+ */
+(function() {
   let inputElements = document.getElementsByTagName('INPUT');
   for (let inputEl of inputElements) {
     if (inputEl.type !== "hidden" && inputEl.type !== "submit" && inputEl.type !== "button") {
       let pos = inputEl.getBoundingClientRect();
-      let topElUnderInput = document.elementFromPoint(pos.x + 2, pos.y + 2);
+      // noticed that sometimes the overlapping element is a little below the actual input field
+      // so make sure we are actually above an overlapping element
+      let posX = pos.x + 2;
+      let posY = pos.y + 2;
+      let topElUnderInput = document.elementFromPoint(posX, posY);
       if (topElUnderInput.tagName !== 'INPUT') {
         // the top most element at the position of the input field isn't the input field itself ...
         while (topElUnderInput.tagName !== 'INPUT') {
           // ... remove click events from it and continue until we reached the input event
+          // by setting pointer-events to none, the elementFromPoint call which change to the next underlying element
+          // see https://stackoverflow.com/questions/14176988/why-is-document-elementfrompoint-affected-by-pointer-events-none
           topElUnderInput.style['pointer-events'] = "none";
-          topElUnderInput = document.elementFromPoint(pos.x + 2, pos.y + 2);
+          topElUnderInput = document.elementFromPoint(posX, posY);
         }
       }
     }
   }
-}, 200);
+}());

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content_scripts/fix-contentEditable.js"],
+      "js": ["content_scripts/fix-contextmenu.js"],
       "run_at": "document_end",
       "all_frames": true
     },


### PR DESCRIPTION
Some sites (e.g. login.live.com) don't use the HTML5 placeholder tag but
uses a custom solution for this (probably because IE < 9 don't support
this). By adding this script we remove any DOM elements living in front
of the input field.

Fixes #80 

@RobinJadoul please provide you opinion if this is the way to go, this has the potential to break some sites. We could also create some content_scripts specific for MS stuff, which are only loaded on the necessary sites. This makes Keywi somehow more bloated, but is probably more reliable.
