### PR TITLE
Improve behaviour when database is locked: try to retrieve credential…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
   },
   "extends": "eslint:all",
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaVersion": 2017
   },
   "rules": {
     "indent": [

--- a/background/commands.js
+++ b/background/commands.js
@@ -27,7 +27,7 @@ browser.commands.onCommand.addListener((cmd) => {
     return;
   }
   browser.tabs.query({'currentWindow': true, 'active': true}).then((tabs) => {
-    Keepass.getLogins(tabs[0].url, (entries) => {
+    Keepass.getLogins(tabs[0].url).then((entries) => {
       browser.tabs.sendMessage(tabs[0].id, {
         'type': type,
         'suppress_error_on_missing_pw_field': true,

--- a/background/contextmenu.js
+++ b/background/contextmenu.js
@@ -64,7 +64,7 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
   if (activeGetLogins.indexOf(tab.id) === -1) {
     // prevent from simultaneous filling in the credentials
     activeGetLogins.push(tab.id);
-    Keepass.getLogins(tab.url, function (entry) {
+    Keepass.getLogins(tab.url).then((entry) => {
       browser.tabs.sendMessage(tab.id, {
         'type': type,
         'username': entry.Login,

--- a/background/request.js
+++ b/background/request.js
@@ -28,7 +28,15 @@ function request (req) {
       }
     ).
       then(function (res) {
-        return res.json();
+        if (res.ok) {
+          return res.json();
+        }
+        if (res.status === 503) {
+          throw new Error('Database unavailable');
+        } else {
+          throw new Error('Error during request');
+        }
+
       });
   });
 }


### PR DESCRIPTION
…s again for some time

When using the option to automatically lock the Keepass database when you lock your computer you'll have to ask Keywi to fill the credentials two times (and there was a bug in it too when using the context menu):
![after](https://user-images.githubusercontent.com/2996275/33513961-8d880272-d74b-11e7-9129-c75bdba22b2f.gif)

With this PR Keywi will retry to retrieve the credentials 20 times, with a 500ms delay between two tries:
![before](https://user-images.githubusercontent.com/2996275/33513959-7c270fc8-d74b-11e7-9f18-77125db94e7e.gif)

For this I had to convert the `Keepass.getLogins` and `Keepass.associate` methods to uses promises instead of callbacks, which was on our TODO list anyway.

@RobinJadoul please give this a good test, it changes some important code.

I'll release a beta when this is merged.
