### PR TITLE
Fix bug which prevents to use the contextmenu after filling credentia…

### DIFF
--- a/background/contextmenu.js
+++ b/background/contextmenu.js
@@ -71,6 +71,8 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
         'password': entry.Password
       });
       activeGetLogins.splice(activeGetLogins.indexOf(tab.id), 1);
+    }, function() {
+      activeGetLogins.splice(activeGetLogins.indexOf(tab.id), 1);
     });
   }
 });

--- a/background/keepass.js
+++ b/background/keepass.js
@@ -192,10 +192,10 @@ Keepass.reCheckAssociated = function () {
   });
 };
 
-Keepass.getLogins = function (url, callback) {
+Keepass.getLogins = function (url, callback, errcallback) {
   if (!this.ready()) {
     Keepass.associate(function () {
-      Keepass.getLogins(url, callback);
+      Keepass.getLogins(url, callback, errcallback);
     });
     return;
   }
@@ -238,6 +238,7 @@ Keepass.getLogins = function (url, callback) {
                 'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
                 'title': 'Keywi'
               }); // TODO replace by injected message
+              errcallback();
             } else if (decryptedEntries.length === 1) {
               callback(decryptedEntries[0]);
             } else {
@@ -257,6 +258,7 @@ Keepass.getLogins = function (url, callback) {
               'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
               'title': 'Keywi'
             });
+            errcallback();
           });
       }).
         catch(function () {
@@ -266,6 +268,7 @@ Keepass.getLogins = function (url, callback) {
             'iconUrl': browser.extension.getURL('icons/keepass-96.png'),
             'title': 'Keywi'
           });
+          errcallback();
         });
     });
   });


### PR DESCRIPTION
…ls failed

Steps to reproduce:
 1. create entry which was never filled before
 2. open the contextmenu and choose to fill password
 3. cancel popup
 4. try to fill credentials again by context menu

Expected behaviour:
 - password gets filled

Actual behaviour:
 - password isn't filled because it's still in https://github.com/LEDfan/keywi/blob/master/background/contextmenu.js#L66