### PR TITLE
Remove "contenteditable" attribute from form elements after filling

### DIFF
--- a/content_scripts/fill-username-and-password.js
+++ b/content_scripts/fill-username-and-password.js
@@ -61,6 +61,7 @@ function writeValueToInputElement(element, value) {
   });
   element.dispatchEvent(event);
   element.dispatchEvent(inputEvent);
+  element.removeAttribute("contenteditable");
 }
 
 browser.runtime.onMessage.addListener(function _func (request, sender, sendResponse) {

--- a/content_scripts/fill-username-and-password.js
+++ b/content_scripts/fill-username-and-password.js
@@ -61,7 +61,9 @@ function writeValueToInputElement(element, value) {
   });
   element.dispatchEvent(event);
   element.dispatchEvent(inputEvent);
-  element.removeAttribute("contenteditable");
+  if (element.type === 'email' || element.type === 'tel') {
+    element.removeAttribute('contenteditable');
+  }
 }
 
 browser.runtime.onMessage.addListener(function _func (request, sender, sendResponse) {


### PR DESCRIPTION
The jQuery Validation plugin has a (fixed) bug causing the validation to
fail when the "contenteditable" property is set on a from field.
See: https://github.com/jquery-validation/jquery-validation/pull/1785

The website mentioned in #101 is using an older version of this library.

Because the contenteditable is re-added on right click this should not cause an issue with the cm (https://github.com/LEDfan/keywi/blob/f950c2ef2dc44e2d9a8949d25d4ae8ca0351d8e0/content_scripts/fix-contentEditable.js#L37)

