### PR TITLE
Supply HTTP passwords (basic auth)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,8 @@
     "no-invalid-this": "off",
     "no-bitwise": "off",
     "space-before-function-paren": "off",
-    "dot-location": "off"
+    "no-loop-func": "warn",
+    "no-undefined": "warn"
   },
   "globals": {
     "cryptoHelpers": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
   },
   "extends": "eslint:all",
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaVersion": 2017
   },
   "rules": {
     "indent": [

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -155,6 +155,10 @@
     "message": "The following page is requesting credentials:",
     "description": "The main body text for the confirm_basic_auth dialog"
   },
+  "dialogConfirmBasicAuthSelect": {
+    "message": "Select a credential:",
+    "description": "The main body text for the confirm_basic_auth dialog"
+  },
   "dialogConfirmBasicAuthFill": {
     "message": "Fetch credentials",
     "description": "The fill option for the confirm_basic_auth dialog"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -159,10 +159,6 @@
     "message": "Use Keywi",
     "description": "The fill option for the confirm_basic_auth dialog"
   },
-  "dialogConfirmBasicAuthSkip": {
-    "message": "Skip Keywi",
-    "description": "The skip option for the confirm_basic_auth dialog"
-  },
   "dialogConfirmBasicAuthPage": {
     "message": "Page:",
     "description": "Used in the confirm_basic_auth dialog with page information"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -179,6 +179,10 @@
     "message": "WARNING: this host is different from the page you're visiting:",
     "description": "Warns the user for differing hosts in the confirm_basic_auth dialog"
   },
+  "dialogConfirmBasicAuthSSLWarning": {
+    "message": "WARNING: The connection is not secured, your credentials will be readable for everyone:",
+    "description": "Warns the user for lack of https in the confirm_basic_auth dialog"
+  },
   "optTitle": {
     "message": "Options for Keywi",
     "description": "The title for the options page"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -156,7 +156,7 @@
     "description": "The main body text for the confirm_basic_auth dialog"
   },
   "dialogConfirmBasicAuthFill": {
-    "message": "Use Keywi",
+    "message": "Fetch credentials",
     "description": "The fill option for the confirm_basic_auth dialog"
   },
   "dialogConfirmBasicAuthPage": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -143,6 +143,42 @@
     "message": "Unlock",
     "description": "Unlock"
   },
+  "dialogConfirmBasicAuthTitle": {
+    "message": "Keywi for HTTP auth",
+    "description": "The title of the confirm_basic_auth dialog"
+  },
+  "dialogConfirmBasicAuthHeader": {
+    "message": "Use Keywi to supply HTTP credentials?",
+    "description": "The header of the confirm_basic_auth dialog"
+  },
+  "dialogConfirmBasicAuthBody": {
+    "message": "The following page is requesting credentials:",
+    "description": "The main body text for the confirm_basic_auth dialog"
+  },
+  "dialogConfirmBasicAuthFill": {
+    "message": "Use Keywi",
+    "description": "The fill option for the confirm_basic_auth dialog"
+  },
+  "dialogConfirmBasicAuthSkip": {
+    "message": "Skip Keywi",
+    "description": "The skip option for the confirm_basic_auth dialog"
+  },
+  "dialogConfirmBasicAuthPage": {
+    "message": "Page:",
+    "description": "Used in the confirm_basic_auth dialog with page information"
+  },
+  "dialogConfirmBasicAuthHost": {
+    "message": "Host:",
+    "description": "Used in the confirm_basic_auth dialog with page information"
+  },
+  "dialogConfirmBasicAuthRealm": {
+    "message": "Realm:",
+    "description": "Used in the confirm_basic_auth dialog with page information"
+  },
+  "dialogConfirmBasicAuthHostWarning": {
+    "message": "WARNING: this host is different from the page you're visiting:",
+    "description": "Warns the user for differing hosts in the confirm_basic_auth dialog"
+  },
   "optTitle": {
     "message": "Options for Keywi",
     "description": "The title for the options page"

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -186,5 +186,45 @@
   "optAssociate": {
     "message": "Associeer met Keepass",
     "description": "options page: text showed on button to associate with Keepass, if not already associated"
+  },
+  "dialogConfirmBasicAuthBody": {
+    "description": "The main body text for the confirm_basic_auth dialog",
+    "message": "~~The following page is requesting credentials:"
+  },
+  "dialogConfirmBasicAuthFill": {
+    "description": "The fill option for the confirm_basic_auth dialog",
+    "message": "~~Fetch credentials"
+  },
+  "dialogConfirmBasicAuthHeader": {
+    "description": "The header of the confirm_basic_auth dialog",
+    "message": "~~Use Keywi to supply HTTP credentials?"
+  },
+  "dialogConfirmBasicAuthHost": {
+    "description": "Used in the confirm_basic_auth dialog with page information",
+    "message": "~~Host:"
+  },
+  "dialogConfirmBasicAuthHostWarning": {
+    "description": "Warns the user for differing hosts in the confirm_basic_auth dialog",
+    "message": "~~WARNING: this host is different from the page you're visiting:"
+  },
+  "dialogConfirmBasicAuthPage": {
+    "description": "Used in the confirm_basic_auth dialog with page information",
+    "message": "~~Page:"
+  },
+  "dialogConfirmBasicAuthRealm": {
+    "description": "Used in the confirm_basic_auth dialog with page information",
+    "message": "~~Realm:"
+  },
+  "dialogConfirmBasicAuthSSLWarning": {
+    "description": "Warns the user for lack of https in the confirm_basic_auth dialog",
+    "message": "~~WARNING: The connection is not secured, your credentials will be readable for everyone:"
+  },
+  "dialogConfirmBasicAuthSelect": {
+    "description": "The main body text for the confirm_basic_auth dialog",
+    "message": "~~Select a credential:"
+  },
+  "dialogConfirmBasicAuthTitle": {
+    "description": "The title of the confirm_basic_auth dialog",
+    "message": "~~Keywi for HTTP auth"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -186,5 +186,45 @@
   "optAssociate": {
     "message": "与 KeePass 建立关联",
     "description": "options page: text showed on button to associate with Keepass, if not already associated"
+  },
+  "dialogConfirmBasicAuthBody": {
+    "description": "The main body text for the confirm_basic_auth dialog",
+    "message": "~~The following page is requesting credentials:"
+  },
+  "dialogConfirmBasicAuthFill": {
+    "description": "The fill option for the confirm_basic_auth dialog",
+    "message": "~~Fetch credentials"
+  },
+  "dialogConfirmBasicAuthHeader": {
+    "description": "The header of the confirm_basic_auth dialog",
+    "message": "~~Use Keywi to supply HTTP credentials?"
+  },
+  "dialogConfirmBasicAuthHost": {
+    "description": "Used in the confirm_basic_auth dialog with page information",
+    "message": "~~Host:"
+  },
+  "dialogConfirmBasicAuthHostWarning": {
+    "description": "Warns the user for differing hosts in the confirm_basic_auth dialog",
+    "message": "~~WARNING: this host is different from the page you're visiting:"
+  },
+  "dialogConfirmBasicAuthPage": {
+    "description": "Used in the confirm_basic_auth dialog with page information",
+    "message": "~~Page:"
+  },
+  "dialogConfirmBasicAuthRealm": {
+    "description": "Used in the confirm_basic_auth dialog with page information",
+    "message": "~~Realm:"
+  },
+  "dialogConfirmBasicAuthSSLWarning": {
+    "description": "Warns the user for lack of https in the confirm_basic_auth dialog",
+    "message": "~~WARNING: The connection is not secured, your credentials will be readable for everyone:"
+  },
+  "dialogConfirmBasicAuthSelect": {
+    "description": "The main body text for the confirm_basic_auth dialog",
+    "message": "~~Select a credential:"
+  },
+  "dialogConfirmBasicAuthTitle": {
+    "description": "The title of the confirm_basic_auth dialog",
+    "message": "~~Keywi for HTTP auth"
   }
 }

--- a/background/basicauth.js
+++ b/background/basicauth.js
@@ -18,6 +18,11 @@
  */
 
 (function() {
+  function extractHost(url) {
+    // Extract host from '<protocol>://<host>/<rest>', includes the port
+    return (/:\/\/([^/]+)\//).exec(url)[1];
+  }
+
   function confirmationDialog(config) {
     const dialogUrl = browser.extension.getURL('dialog/confirm_basic_auth.html');
     return browser.windows.create({
@@ -93,10 +98,11 @@
     return browser.tabs.get(details.tabId)
       .then(function (tab) {
         // Prevent looking at the old url when the page hasn't properly loaded yet
+        const host = extractHost(details.url);
         const pageHost = details.frameId === 0
-          ? details.challenger.host
-          : (/:\/\/([^/]+)\//).exec(tab.url)[1];
-        return confirmationDialog({'url': details.url, 'host': details.challenger.host, 'realm': details.realm, 'page_host': pageHost});
+          ? host
+          : extractHost(tab.url);
+        return confirmationDialog({'url': details.url, 'host': host, 'realm': details.realm, 'page_host': pageHost});
       })
       .then(function (choice) {
         if (choice === 'fill') {

--- a/background/basicauth.js
+++ b/background/basicauth.js
@@ -95,15 +95,13 @@
       return;
     }
     // TODO? track retries
-    return browser.tabs.get(details.tabId)
-      .then(function (tab) {
-        // Prevent looking at the old url when the page hasn't properly loaded yet
-        const host = extractHost(details.url);
-        const pageHost = details.frameId === 0
-          ? host
-          : extractHost(tab.url);
-        return confirmationDialog({'url': details.url, 'host': host, 'realm': details.realm, 'page_host': pageHost});
-      })
+    let pageHost;
+    if (typeof details.originUrl !== 'undefined') {
+      pageHost = extractHost(details.originUrl)
+    } else {
+      pageHost = details.challenger.host;
+    }
+    return confirmationDialog({'url': details.url, 'host': details.challenger.host, 'realm': details.realm, 'page_host': pageHost})
       .then(function (choice) {
         if (choice === 'fill') {
           return queryDB(details.url);

--- a/background/basicauth.js
+++ b/background/basicauth.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Robin Jadoul
+ * @copyright Tobia De Koninck
  *
  * Copyright (C) 2018  Robin Jadoul
  * This file is part of Keywi.
@@ -23,7 +24,7 @@
     return (/:\/\/([^/]+)\//).exec(url)[1];
   }
 
-  function  confirmationDialog(config) {
+  function confirmationDialog(config) {
     const dialogUrl = browser.extension.getURL('dialog/confirm_basic_auth.html');
     return browser.windows.create({
       'type': 'panel',
@@ -35,7 +36,7 @@
       const openedWindowId = newWindow.id;
 
       return new Promise(function(resolve, reject) {
-        browser.tabs.query({"windowId": openedWindowId}).then(function (tabs) {
+        browser.tabs.query({'windowId': openedWindowId}).then(function (tabs) {
           const openTabId = tabs[0].id;
           browser.tabs.onUpdated.addListener(function _sendData(tabId, changeInfo, tabInfo) {
             if (tabId === openTabId && tabInfo.status === 'complete') {
@@ -52,7 +53,7 @@
 
         function _onRemove(winId) {
           if (openedWindowId === winId) {
-            clean();
+            clean(); // eslint-disable-line no-use-before-define
             reject();
           }
         }
@@ -62,17 +63,17 @@
             Keepass.getLoginsAndErrorHandler(config.url).then((resp) => {
               sendResponse(resp);
             }, () => {
-              clean();
+              clean(); // eslint-disable-line no-use-before-define
               reject();
             });
 
             return true;
           } else if (request.type === 'confirm_basic_auth_select') {
-            clean();
-            resolve({"code": 'fill', 'username': request.data.selected.Login, 'password': request.data.selected.Password});
+            clean(); // eslint-disable-line no-use-before-define
+            resolve({'code': 'fill', 'username': request.data.selected.Login, 'password': request.data.selected.Password});
           } else if (request.type === 'confirm_basic_auth_cancel') {
-            clean();
-            resolve({"code" : 'cancel'});
+            clean(); // eslint-disable-line no-use-before-define
+            resolve({'code': 'cancel'});
           }
         }
 
@@ -96,15 +97,15 @@
     // TODO? track retries
     let pageHost;
     if (typeof details.originUrl !== 'undefined') {
-      pageHost = extractHost(details.originUrl)
+      pageHost = extractHost(details.originUrl);
     } else {
       pageHost = details.challenger.host;
     }
-    return confirmationDialog({'url': details.url, 'host': details.challenger.host, 'realm': details.realm, 'page_host': pageHost})
-      .then(function (response) {
+    return confirmationDialog({'url': details.url, 'host': details.challenger.host, 'realm': details.realm, 'page_host': pageHost}).
+      then(function (response) {
 
         if (response.code === 'fill') {
-          return {"authCredentials": {"username": response.username, "password": response.password}};
+          return {'authCredentials': {'username': response.username, 'password': response.password}};
         } else if (response.code === 'cancel') {
           return {};
         }

--- a/background/basicauth.js
+++ b/background/basicauth.js
@@ -1,17 +1,111 @@
-browser.webRequest.onAuthRequired.addListener(function(details) {
-  if (details.isProxy) {
-    // Don't do proxy's, at least for now
-    return;
-  }
-  // TODO: confirm dialog with
-  //   - details.realm if available
-  //   - details.host or details.url
-  //  This will also prevent invalid password infinite loops, since the user gets queried every time
-  return new Promise(function(resolve, reject) {
-    Keepass.getLogins(details.url, function(entry) {
-      resolve({'authCredentials': {'username': entry.Login, 'password': entry.Password}});
-    }, function() {
-      resolve({});
+/**
+ * @copyright Robin Jadoul
+ *
+ * Copyright (C) 2018  Robin Jadoul
+ * This file is part of Keywi.
+ * Keywi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Keywi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Keywi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+(function() {
+  function confirmationDialog(url, host, realm, pageHost) {
+    const dialogUrl = browser.extension.getURL('dialog/confirm_basic_auth.html');
+    return browser.windows.create({
+      'type': 'panel',
+      'width': 400,
+      'height': 600,
+      'url': dialogUrl,
+      'incognito': true
+    }).then(function (newWindow) {
+      const openedWindowId = newWindow.id;
+
+      return new Promise(function(resolve, reject) {
+        browser.tabs.query({'windowId': openedWindowId}).then(function (tabs) {
+          const openTabId = tabs[0].id;
+          browser.tabs.onUpdated.addListener(function _sendData(tabId, changeInfo, tabInfo) {
+            if (tabId === openTabId && tabInfo.status === 'complete') {
+              setTimeout(function () {
+                browser.tabs.sendMessage(openTabId, {
+                  'type': 'confirm_basic_auth_data',
+                  'data': {'url': url, 'host': host, 'realm': realm, 'page_host': pageHost}
+                });
+                browser.tabs.onUpdated.removeListener(_sendData);
+              }, 300);
+            }
+          });
+        });
+
+        function _onRemove(winId) {
+          if (openedWindowId === winId) {
+            clean();
+            reject();
+          }
+        }
+
+        function _handler(request, sender, sendResponse) {
+          if (request.type === 'confirm_basic_auth_fill') {
+            clean();
+            resolve('fill');
+          } else if (request.type === 'confirm_basic_auth_manual') {
+            clean();
+            resolve('manual');
+          } else if (request.type === 'confirm_basic_auth_cancel') {
+            clean();
+            resolve('cancel');
+          }
+        }
+
+        function clean() {
+          browser.runtime.onMessage.removeListener(_handler);
+          browser.windows.onRemoved.removeListener(_onRemove);
+          browser.windows.remove(newWindow.id);
+        }
+
+        browser.windows.onRemoved.addListener(_onRemove);
+        browser.runtime.onMessage.addListener(_handler);
+      });
     });
-  });
-}, {'urls': ['<all_urls>']}, ['blocking']);
+  }
+
+  function queryDB(url) {
+    return new Promise(function(resolve, reject) {
+      Keepass.getLogins(url, function(entry) {
+        resolve({'authCredentials': {'username': entry.Login, 'password': entry.Password}});
+      }, function() {
+        resolve({});
+      });
+    });
+  }
+
+  browser.webRequest.onAuthRequired.addListener(function(details) {
+    if (details.isProxy) {
+      // Don't do proxy's, at least for now
+      return;
+    }
+    // TODO? track retries
+    return browser.tabs.get(details.tabId)
+      .then(function (tab) {
+        const pageHost = (/:\/\/([^/]+)\//).exec(tab.url)[1];
+        return confirmationDialog(details.url, details.challenger.host, details.realm, pageHost);
+      })
+      .then(function (choice) {
+        if (choice === 'fill') {
+          return queryDB(details.url);
+        } else if (choice === 'manual') {
+          return {};
+        } else if (choice === 'cancel') {
+          return {'cancel': true};
+        }
+      });
+  }, {'urls': ['<all_urls>']}, ['blocking']);
+}());

--- a/background/basicauth.js
+++ b/background/basicauth.js
@@ -56,9 +56,6 @@
           if (request.type === 'confirm_basic_auth_fill') {
             clean();
             resolve('fill');
-          } else if (request.type === 'confirm_basic_auth_manual') {
-            clean();
-            resolve('manual');
           } else if (request.type === 'confirm_basic_auth_cancel') {
             clean();
             resolve('cancel');
@@ -104,10 +101,8 @@
       .then(function (choice) {
         if (choice === 'fill') {
           return queryDB(details.url);
-        } else if (choice === 'manual') {
-          return {};
         } else if (choice === 'cancel') {
-          return {'cancel': true};
+          return {};
         }
       });
   }, {'urls': ['<all_urls>']}, ['blocking']);

--- a/background/basicauth.js
+++ b/background/basicauth.js
@@ -89,26 +89,28 @@
     });
   }
 
-  browser.webRequest.onAuthRequired.addListener(function(details) {
-    if (details.isProxy) {
-      // Don't do proxy's, at least for now
-      return;
-    }
-    // TODO? track retries
-    let pageHost;
-    if (typeof details.originUrl !== 'undefined') {
-      pageHost = extractHost(details.originUrl);
-    } else {
-      pageHost = details.challenger.host;
-    }
-    return confirmationDialog({'url': details.url, 'host': details.challenger.host, 'realm': details.realm, 'page_host': pageHost}).
-      then(function (response) {
+  // only supported on FF >= 54, but 52 is an ESR version
+  if (typeof browser.webRequest.onAuthRequired !== 'undefined') {
+    browser.webRequest.onAuthRequired.addListener(function(details) {
+      if (details.isProxy) {
+        // Don't do proxy's, at least for now
+        return;
+      }
+      let pageHost;
+      if (typeof details.originUrl !== 'undefined') {
+        pageHost = extractHost(details.originUrl);
+      } else {
+        pageHost = details.challenger.host;
+      }
+      return confirmationDialog({'url': details.url, 'host': details.challenger.host, 'realm': details.realm, 'page_host': pageHost}).
+        then(function (response) {
 
-        if (response.code === 'fill') {
-          return {'authCredentials': {'username': response.username, 'password': response.password}};
-        } else if (response.code === 'cancel') {
-          return {};
-        }
-      });
-  }, {'urls': ['<all_urls>']}, ['blocking']);
+          if (response.code === 'fill') {
+            return {'authCredentials': {'username': response.username, 'password': response.password}};
+          } else if (response.code === 'cancel') {
+            return {};
+          }
+        });
+    }, {'urls': ['<all_urls>']}, ['blocking']);
+  }
 }());

--- a/background/basicauth.js
+++ b/background/basicauth.js
@@ -1,0 +1,17 @@
+browser.webRequest.onAuthRequired.addListener(function(details) {
+  if (details.isProxy) {
+    // Don't do proxy's, at least for now
+    return;
+  }
+  // TODO: confirm dialog with
+  //   - details.realm if available
+  //   - details.host or details.url
+  //  This will also prevent invalid password infinite loops, since the user gets queried every time
+  return new Promise(function(resolve, reject) {
+    Keepass.getLogins(details.url, function(entry) {
+      resolve({'authCredentials': {'username': entry.Login, 'password': entry.Password}});
+    }, function() {
+      resolve({});
+    });
+  });
+}, {'urls': ['<all_urls>']}, ['blocking']);

--- a/background/commands.js
+++ b/background/commands.js
@@ -27,7 +27,7 @@ browser.commands.onCommand.addListener((cmd) => {
     return;
   }
   browser.tabs.query({'currentWindow': true, 'active': true}).then((tabs) => {
-    Keepass.getLogins(tabs[0].url).then((entries) => {
+    Keepass.getGUILogins(tabs[0].url).then((entries) => {
       browser.tabs.sendMessage(tabs[0].id, {
         'type': type,
         'suppress_error_on_missing_pw_field': true,

--- a/background/commands.js
+++ b/background/commands.js
@@ -27,7 +27,7 @@ browser.commands.onCommand.addListener((cmd) => {
     return;
   }
   browser.tabs.query({'currentWindow': true, 'active': true}).then((tabs) => {
-    Keepass.getLogins(tabs[0].url, (entries) => {
+    Keepass.getLogins(tabs[0].url).then((entries) => {
       browser.tabs.sendMessage(tabs[0].id, {
         'type': type,
         'suppress_error_on_missing_pw_field': true,

--- a/background/contextmenu.js
+++ b/background/contextmenu.js
@@ -64,7 +64,7 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
   if (activeGetLogins.indexOf(tab.id) === -1) {
     // prevent from simultaneous filling in the credentials
     activeGetLogins.push(tab.id);
-    Keepass.getLogins(tab.url, function (entry) {
+    Keepass.getLogins(tab.url).then((entry) => {
       browser.tabs.sendMessage(tab.id, {
         'type': type,
         'username': entry.Login,

--- a/background/contextmenu.js
+++ b/background/contextmenu.js
@@ -64,7 +64,7 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
   if (activeGetLogins.indexOf(tab.id) === -1) {
     // prevent from simultaneous filling in the credentials
     activeGetLogins.push(tab.id);
-    Keepass.getLogins(tab.url).then((entry) => {
+    Keepass.getGUILogins(tab.url).then((entry) => {
       browser.tabs.sendMessage(tab.id, {
         'type': type,
         'username': entry.Login,

--- a/background/init.js
+++ b/background/init.js
@@ -48,6 +48,7 @@ function init () {
     }).
       catch(function (ss) {
         console.log('Failed to initialize Secure Storage, not associating with keepass!');
+        console.log(ss);
         browser.notifications.create({
           'type': 'basic',
           'message': browser.i18n.getMessage('initSSFailed'),

--- a/background/init.js
+++ b/background/init.js
@@ -48,7 +48,6 @@ function init () {
     }).
       catch(function (ss) {
         console.log('Failed to initialize Secure Storage, not associating with keepass!');
-        console.log(ss);
         browser.notifications.create({
           'type': 'basic',
           'message': browser.i18n.getMessage('initSSFailed'),

--- a/background/keepass.js
+++ b/background/keepass.js
@@ -21,10 +21,6 @@
  * This file holds the main API to the Keepass Database
  */
 
-async function sleep(time) {
-  await new Promise((resolve) => setTimeout(resolve, time));
-}
-
 const Keepass = {};
 
 Keepass._ss = null;
@@ -184,28 +180,11 @@ Keepass.reCheckAssociated = function () {
           'Id': id
         };
 
-        browser.storage.local.get('keepass-server-url').then(async function(pref) {
-          let tryagain = true;
-          let tries = 20;
-          while (tryagain && tries !== 0) {
-            // eslint-disable-next-line no-await-in-loop, no-loop-func
-            await request(req).then((resp) => {
-              Keepass.state.associated = Boolean(resp.Success);
-              resolve(resp.Success);
-              tryagain = false;
-            }).
-              // eslint-disable-next-line no-loop-func
-              catch(async (res) => {
-                console.log(res);
-                if (res.message === 'Database unavailable') {
-                  tries--;
-                  await sleep(500);
-                } else {
-                  resolve(false);
-                  tryagain = false;
-                }
-              });
-          }
+        browser.storage.local.get('keepass-server-url').then(function (pref) {
+          request(req).then(function (resp) {
+            Keepass.state.associated = Boolean(resp.Success);
+            resolve(resp.Success);
+          });
         });
       }).
         catch(function () {

--- a/background/keepass.js
+++ b/background/keepass.js
@@ -297,7 +297,7 @@ Keepass.getGUILogins = function(url) {
     if (credentials.length === 1) {
      return credentials[0];
     } else {
-      return self.prompts._selectCredentials(credentials);
+      return Keepass.prompts._selectCredentials(credentials);
     }
   });
 };

--- a/background/keepass.js
+++ b/background/keepass.js
@@ -201,9 +201,7 @@ Keepass.reCheckAssociated = function () {
 
 Keepass.getLogins = function(url) {
   if (!this.ready()) {
-    return Keepass.associate().then(() => {
-      return Keepass.getLogins(url);
-    });
+    return Keepass.associate().then(() => Keepass.getLogins(url));
   }
 
   return new Promise(function (resolve, reject) {
@@ -213,45 +211,53 @@ Keepass.getLogins = function(url) {
     const decryptedEntries = [];
     Keepass._ss.get('database.key').then(function (keyParam) {
       key = keyParam;
-      return Keepass._ss.get('database.id')
-    }).then(function (id) {
-      const verifiers = Crypto.generateVerifier(key);
+      return Keepass._ss.get('database.id');
+    }).
+      then(function (id) {
+        const verifiers = Crypto.generateVerifier(key);
 
-      const req = {
-        'RequestType': 'get-logins',
-        'SortSelection': true,
-        'TriggerUnlock': false,
-        'Nonce': verifiers[0],
-        'Verifier': verifiers[1],
-        'Id': id,
-        'Url': Crypto.encrypt(url, key, verifiers[0]),
-        'SubmitUrl': null
-      };
+        const req = {
+          'RequestType': 'get-logins',
+          'SortSelection': true,
+          'TriggerUnlock': false,
+          'Nonce': verifiers[0],
+          'Verifier': verifiers[1],
+          'Id': id,
+          'Url': Crypto.encrypt(url, key, verifiers[0]),
+          'SubmitUrl': null
+        };
 
-      return request(req);
-    }).then(function (respParam) {
-      resp = respParam;
-      return Keepass.helpers.verifyResponse(resp, key)
-    }, function() {
-      reject({code: 'cannotConnect'});
-    }).then(function () {
-      const rIv = resp.Nonce;
-      let promiseChain = Promise.resolve();
-      for (let i = 0; i < resp.Entries.length; i++) {
-        promiseChain = promiseChain.then(function() {
-          return Keepass.helpers.decryptEntry(resp.Entries[i], rIv).then(function(decryptedEntry) {
-            decryptedEntries.push(decryptedEntry);
+        return request(req);
+      }).
+      then(function (respParam) {
+        resp = respParam;
+        return Keepass.helpers.verifyResponse(resp, key);
+      }, function() {
+        reject({'code': 'cannotConnect'});
+      }).
+      then(function () {
+        console.log('here');
+        const rIv = resp.Nonce;
+        let promiseChain = Promise.resolve();
+        for (let i = 0; i < resp.Entries.length; i++) {
+          promiseChain = promiseChain.then(function() {
+            return Keepass.helpers.decryptEntry(resp.Entries[i], rIv).then((decryptedEntry) => decryptedEntries.push(decryptedEntry));
           });
-        });
-      }
-      return promiseChain;
-    }).then(function () {
-      resolve(decryptedEntries);
-    }).catch(function () {
-      console.log(`RetrieveCredentials for ${url} failed`);
+        }
+        console.log('not here');
+        return promiseChain;
+      }).
+      then(function () {
+        console.log('ok here');
+        console.log(decryptedEntries);
+        resolve(decryptedEntries);
+      }).
+      catch(function (err) {
+        console.log(err);
+        console.log(`RetrieveCredentials for ${url} failed`);
 
-      reject({code: 'noLogins'});
-    });
+        reject({'code': 'noLogins'});
+      });
   });
 };
 
@@ -265,7 +271,7 @@ Keepass.getLoginsAndErrorHandler = function (url) {
           'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
           'title': 'Keywi'
         });
-        reject({code: 'noPassFound'});
+        reject({'code': 'noPassFound'});
       } else {
         resolve(credentials);
       }
@@ -295,10 +301,10 @@ Keepass.getLoginsAndErrorHandler = function (url) {
 Keepass.getGUILogins = function(url) {
   return Keepass.getLoginsAndErrorHandler(url).then((credentials) => {
     if (credentials.length === 1) {
-     return credentials[0];
-    } else {
-      return Keepass.prompts._selectCredentials(credentials);
+      return credentials[0];
     }
+    return Keepass.prompts._selectCredentials(credentials);
+
   });
 };
 
@@ -325,10 +331,7 @@ Keepass.associate = function () {
      * If it was done the other way around, then if setting up the secure storage would fail
      * the association request would still be done, but the result couldn't be saved
      */
-    return Keepass._ss.reInitialize().
-      then(function () {
-        return Keepass.associate();
-      });
+    return Keepass._ss.reInitialize().then(Keepass.associate);
   }
 
   // test if we are already associated and it's working

--- a/background/keepass.js
+++ b/background/keepass.js
@@ -276,7 +276,7 @@ Keepass.getLogins = function(url) {
   });
 };
 
-Keepass.getGUILogins = function (url) {
+Keepass.getLoginsAndErrorHandler = function (url) {
   return new Promise(function(resolve, reject) {
     Keepass.getLogins(url).then(function(credentials) {
       if (credentials.length === 0) {
@@ -287,12 +287,8 @@ Keepass.getGUILogins = function (url) {
           'title': 'Keywi'
         });
         reject({code: 'noPassFound'});
-      } else if (credentials.length === 1) {
-        resolve(credentials[0]);
       } else {
-        self.prompts._selectCredentials(credentials).then(function (selectedCredential) {
-          resolve(selectedCredential);
-        });
+        resolve(credentials);
       }
     }, function(data) {
       if (data.code === 'cannotConnect') {
@@ -314,6 +310,16 @@ Keepass.getGUILogins = function (url) {
       }
     });
 
+  });
+};
+
+Keepass.getGUILogins = function(url) {
+  return Keepass.getLoginsAndErrorHandler(url).then((credentials) => {
+    if (credentials.length === 1) {
+     return credentials[0];
+    } else {
+      return self.prompts._selectCredentials(credentials);
+    }
   });
 };
 

--- a/background/keepass.js
+++ b/background/keepass.js
@@ -236,7 +236,6 @@ Keepass.getLogins = function(url) {
         reject({'code': 'cannotConnect'});
       }).
       then(function () {
-        console.log('here');
         const rIv = resp.Nonce;
         let promiseChain = Promise.resolve();
         for (let i = 0; i < resp.Entries.length; i++) {
@@ -244,16 +243,12 @@ Keepass.getLogins = function(url) {
             return Keepass.helpers.decryptEntry(resp.Entries[i], rIv).then((decryptedEntry) => decryptedEntries.push(decryptedEntry));
           });
         }
-        console.log('not here');
         return promiseChain;
       }).
       then(function () {
-        console.log('ok here');
-        console.log(decryptedEntries);
         resolve(decryptedEntries);
       }).
-      catch(function (err) {
-        console.log(err);
+      catch(function () {
         console.log(`RetrieveCredentials for ${url} failed`);
 
         reject({'code': 'noLogins'});

--- a/background/keepass.js
+++ b/background/keepass.js
@@ -21,6 +21,10 @@
  * This file holds the main API to the Keepass Database
  */
 
+async function sleep(time) {
+  await new Promise((resolve) => setTimeout(resolve, time));
+}
+
 const Keepass = {};
 
 Keepass._ss = null;
@@ -92,6 +96,11 @@ Keepass.helpers.decryptEntry = function (entry, iv) {
 
 Keepass.prompts = {};
 
+/**
+ * @brief Shows a prompt to the user to select one of multiple credentials.
+ * @param possibleCredentials
+ * @private
+ */
 Keepass.prompts._selectCredentials = function (possibleCredentials) {
   return new Promise(function (resolve, reject) {
     const url = browser.extension.getURL('dialog/select_multiple_passwords.html');
@@ -175,11 +184,28 @@ Keepass.reCheckAssociated = function () {
           'Id': id
         };
 
-        browser.storage.local.get('keepass-server-url').then(function (pref) {
-          request(req).then(function (resp) {
-            Keepass.state.associated = Boolean(resp.Success);
-            resolve(resp.Success);
-          });
+        browser.storage.local.get('keepass-server-url').then(async function(pref) {
+          let tryagain = true;
+          let tries = 20;
+          while (tryagain && tries !== 0) {
+            // eslint-disable-next-line no-await-in-loop, no-loop-func
+            await request(req).then((resp) => {
+              Keepass.state.associated = Boolean(resp.Success);
+              resolve(resp.Success);
+              tryagain = false;
+            }).
+              // eslint-disable-next-line no-loop-func
+              catch(async (res) => {
+                console.log(res);
+                if (res.message === 'Database unavailable') {
+                  tries--;
+                  await sleep(500);
+                } else {
+                  resolve(false);
+                  tryagain = false;
+                }
+              });
+          }
         });
       }).
         catch(function () {
@@ -194,18 +220,22 @@ Keepass.reCheckAssociated = function () {
   });
 };
 
-Keepass.getLogins = function (url, callback, errcallback) {
+Keepass.getLogins = function(url) {
   if (!this.ready()) {
-    Keepass.associate(function () {
-      Keepass.getLogins(url, callback, errcallback);
+    return Keepass.associate().then(() => {
+      return Keepass.getLogins(url);
     });
-    return;
   }
 
-  const self = this;
+  return new Promise(function (resolve, reject) {
 
-  Keepass._ss.get('database.key').then(function (key) {
-    Keepass._ss.get('database.id').then(function (id) {
+    let key;
+    let resp;
+    const decryptedEntries = [];
+    Keepass._ss.get('database.key').then(function (keyParam) {
+      key = keyParam;
+      return Keepass._ss.get('database.id')
+    }).then(function (id) {
       const verifiers = Crypto.generateVerifier(key);
 
       const req = {
@@ -218,61 +248,72 @@ Keepass.getLogins = function (url, callback, errcallback) {
         'Url': Crypto.encrypt(url, key, verifiers[0]),
         'SubmitUrl': null
       };
-      request(req).then(function (resp) {
-        Keepass.helpers.verifyResponse(resp, key).then(function () {
-          const rIv = resp.Nonce;
-          const decryptedEntries = [];
-          let promiseChain = Promise.resolve();
-          for (let i = 0; i < resp.Entries.length; i++) {
-            promiseChain = promiseChain.then(function () {
-              return Keepass.helpers.decryptEntry(resp.Entries[i], rIv).then(function (decryptedEntry) {
-                // callback([decryptedEntry]);
-                decryptedEntries.push(decryptedEntry);
-              });
-            });
-          }
-          promiseChain.then(function () {
-            // decrypted all entries
-            if (decryptedEntries.length === 0) {
-              browser.notifications.create({
-                'type': 'basic',
-                'message': browser.i18n.getMessage('noPassFound'),
-                'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
-                'title': 'Keywi'
-              }); // TODO replace by injected message
-              errcallback();
-            } else if (decryptedEntries.length === 1) {
-              callback(decryptedEntries[0]);
-            } else {
-              self.prompts._selectCredentials(decryptedEntries).then(function (selectedCredential) {
-                callback(selectedCredential);
-              });
 
-            }
+      return request(req);
+    }).then(function (respParam) {
+      resp = respParam;
+      return Keepass.helpers.verifyResponse(resp, key)
+    }, function() {
+      reject({code: 'cannotConnect'});
+    }).then(function () {
+      const rIv = resp.Nonce;
+      let promiseChain = Promise.resolve();
+      for (let i = 0; i < resp.Entries.length; i++) {
+        promiseChain = promiseChain.then(function() {
+          return Keepass.helpers.decryptEntry(resp.Entries[i], rIv).then(function(decryptedEntry) {
+            decryptedEntries.push(decryptedEntry);
           });
-        }).
-          catch(function () {
-            console.log(`RetrieveCredentials for ${url} rejected`);
-
-            browser.notifications.create({
-              'type': 'basic',
-              'message': browser.i18n.getMessage('noLogins'),
-              'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
-              'title': 'Keywi'
-            });
-            errcallback();
-          });
-      }).
-        catch(function () {
-          browser.notifications.create({
-            'type': 'basic',
-            'message': browser.i18n.getMessage('cannotConnect'),
-            'iconUrl': browser.extension.getURL('icons/keepass-96.png'),
-            'title': 'Keywi'
-          });
-          errcallback();
         });
+      }
+      return promiseChain;
+    }).then(function () {
+      resolve(decryptedEntries);
+    }).catch(function () {
+      console.log(`RetrieveCredentials for ${url} failed`);
+
+      reject({code: 'noLogins'});
     });
+  });
+};
+
+Keepass.getGUILogins = function (url) {
+  return new Promise(function(resolve, reject) {
+    Keepass.getLogins(url).then(function(credentials) {
+      if (credentials.length === 0) {
+        browser.notifications.create({
+          'type': 'basic',
+          'message': browser.i18n.getMessage('noPassFound'),
+          'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
+          'title': 'Keywi'
+        });
+        reject({code: 'noPassFound'});
+      } else if (credentials.length === 1) {
+        resolve(credentials[0]);
+      } else {
+        self.prompts._selectCredentials(credentials).then(function (selectedCredential) {
+          resolve(selectedCredential);
+        });
+      }
+    }, function(data) {
+      if (data.code === 'cannotConnect') {
+        browser.notifications.create({
+          'type': 'basic',
+          'message': browser.i18n.getMessage('cannotConnect'),
+          'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
+          'title': 'Keywi'
+        });
+        reject();
+      } else if (data.code === 'noLogins') {
+        browser.notifications.create({
+          'type': 'basic',
+          'message': browser.i18n.getMessage('noLogins'),
+          'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
+          'title': 'Keywi'
+        });
+        reject();
+      }
+    });
+
   });
 };
 
@@ -289,7 +330,7 @@ Keepass.deassociate = function () {
     });
 };
 
-Keepass.associate = function (callback) {
+Keepass.associate = function () {
 
   if (!Keepass._ss.ready()) {
 
@@ -299,58 +340,62 @@ Keepass.associate = function (callback) {
      * If it was done the other way around, then if setting up the secure storage would fail
      * the association request would still be done, but the result couldn't be saved
      */
-    Keepass._ss.reInitialize().then(function () {
-      Keepass.associate(callback);
-    });
-    return;
+    return Keepass._ss.reInitialize().
+      then(function () {
+        return Keepass.associate();
+      });
   }
 
   // test if we are already associated and it's working
-  this.reCheckAssociated().then(function (associated) {
-    if (associated) {
-      callback();
-    } else {
-      const rawKey = cryptoHelpers.generateSharedKey(Crypto.keySize * 2);
-      const key = btoa(cryptoHelpers.convertByteArrayToString(rawKey));
-      const verifiers = Crypto.generateVerifier(key);
+  return this.reCheckAssociated().then(function (associated) {
+    return new Promise(function (resolve, reject) {
+      if (associated) {
+        // callback();
+        resolve();
+      } else {
+        const rawKey = cryptoHelpers.generateSharedKey(Crypto.keySize * 2);
+        const key = btoa(cryptoHelpers.convertByteArrayToString(rawKey));
+        const verifiers = Crypto.generateVerifier(key);
 
-      const req = {
-        'RequestType': 'associate',
-        'Key': key,
-        'Nonce': verifiers[0],
-        'Verifier': verifiers[1]
-      };
-      request(req).then(function (resp) {
-        if (resp.Success) {
-          Keepass._ss.set('database.id', resp.Id).
-            then(function () {
-              return Keepass._ss.set('database.key', key);
-            }).
-            then(function () {
-              return Keepass._ss.set('database.hash', resp.Hash);
-            }).
-            then(function () {
-              Keepass.state.associated = true;
-              callback();
+        const req = {
+          'RequestType': 'associate',
+          'Key': key,
+          'Nonce': verifiers[0],
+          'Verifier': verifiers[1]
+        };
+        request(req).then(function (resp) {
+          if (resp.Success) {
+            Keepass._ss.set('database.id', resp.Id).
+              then(function () {
+                return Keepass._ss.set('database.key', key);
+              }).
+              then(function () {
+                return Keepass._ss.set('database.hash', resp.Hash);
+              }).
+              then(function () {
+                Keepass.state.associated = true;
+                // callback();
+                resolve();
+              });
+          } else {
+            browser.notifications.create({
+              'type': 'basic',
+              'message': browser.i18n.getMessage('assocFailed'),
+              'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
+              'title': 'Keywi'
             });
-        } else {
-          browser.notifications.create({
-            'type': 'basic',
-            'message': browser.i18n.getMessage('assocFailed'),
-            'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
-            'title': 'Keywi'
+          }
+        }).
+          catch(function () {
+            browser.notifications.create({
+              'type': 'basic',
+              'message': browser.i18n.getMessage('cannotConnect'),
+              'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
+              'title': 'Keywi'
+            });
           });
-        }
-      }).
-        catch(function () {
-          browser.notifications.create({
-            'type': 'basic',
-            'message': browser.i18n.getMessage('cannotConnect'),
-            'iconUrl': browser.extension.getURL('icons/keywi-96.png'),
-            'title': 'Keywi'
-          });
-        });
-    }
+      }
+    });
   });
 };
 

--- a/background/request.js
+++ b/background/request.js
@@ -28,7 +28,15 @@ function request (req) {
       }
     ).
       then(function (res) {
-        return res.json();
+        if (res.ok) {
+          return res.json();
+        }
+        if (res.status === 503) {
+          throw new Error('Database unavailable');
+        } else {
+          throw new Error('Error during request');
+        }
+
       });
   });
 }

--- a/content_scripts/hacks.js
+++ b/content_scripts/hacks.js
@@ -27,9 +27,9 @@
  * see https://github.com/LEDfan/keywi/pull/84
  */
 function applyHacks() {
-  fetch(browser.extension.getURL('content_scripts/hacks.json'))
-    .then((resp) => resp.json())
-    .then((hacks) => {
+  fetch(browser.extension.getURL('content_scripts/hacks.json')).
+    then((resp) => resp.json()).
+    then((hacks) => {
       Object.keys(hacks).forEach((pat) => {
         if (window.location.href.search(new RegExp(pat)) !== -1) {
           for (const el of document.querySelectorAll(hacks[pat])) {

--- a/dialog/confirm_basic_auth.css
+++ b/dialog/confirm_basic_auth.css
@@ -28,6 +28,29 @@
   font-family: monospace;
   font-size: 0.8em;
 }
-#form.force {
-  height: 100px;
+/*#form.force {*/
+  /*height: 100px;*/
+/*}*/
+
+.password-choose-btn {
+  color: #fff;
+  background-color: #5cb85c;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  width: 340px;
+  padding: 5px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  box-sizing: border-box;
+}
+
+#passwords {
+  height: 260px;
+  overflow-y: auto;
+}
+
+
+#cancel-container {
+  height: 60px;
+  padding-top: 10px;
 }

--- a/dialog/confirm_basic_auth.css
+++ b/dialog/confirm_basic_auth.css
@@ -25,4 +25,6 @@
 }
 .request-info {
   font-style: italic;
+  font-family: monospace;
+  font-size: 0.8em;
 }

--- a/dialog/confirm_basic_auth.css
+++ b/dialog/confirm_basic_auth.css
@@ -1,0 +1,28 @@
+/**
+ * @copyright Robin Jadoul
+ *
+ * Copyright (C) 2018  Robin Jadoul
+ * This file is part of Keywi.
+ * Keywi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Keywi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Keywi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.hidden {
+  display:none;
+}
+.warning {
+  color: #d9534f;
+}
+.request-info {
+  font-style: italic;
+}

--- a/dialog/confirm_basic_auth.css
+++ b/dialog/confirm_basic_auth.css
@@ -28,3 +28,6 @@
   font-family: monospace;
   font-size: 0.8em;
 }
+#form.force {
+  height: 100px;
+}

--- a/dialog/confirm_basic_auth.css
+++ b/dialog/confirm_basic_auth.css
@@ -28,29 +28,4 @@
   font-family: monospace;
   font-size: 0.8em;
 }
-/*#form.force {*/
-  /*height: 100px;*/
-/*}*/
 
-.password-choose-btn {
-  color: #fff;
-  background-color: #5cb85c;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  width: 340px;
-  padding: 5px;
-  margin-top: 5px;
-  margin-bottom: 5px;
-  box-sizing: border-box;
-}
-
-#passwords {
-  height: 260px;
-  overflow-y: auto;
-}
-
-
-#cancel-container {
-  height: 60px;
-  padding-top: 10px;
-}

--- a/dialog/confirm_basic_auth.css
+++ b/dialog/confirm_basic_auth.css
@@ -1,5 +1,6 @@
 /**
  * @copyright Robin Jadoul
+ * @copyright Tobia De Koninck
  *
  * Copyright (C) 2018  Robin Jadoul
  * This file is part of Keywi.

--- a/dialog/confirm_basic_auth.html
+++ b/dialog/confirm_basic_auth.html
@@ -1,5 +1,6 @@
 <!--
   * @copyright Robin Jadoul
+  * @copyright Tobia De Koninck
   *
   * Copyright (C) 2018  Robin Jadoul
   * This file is part of Keywi.

--- a/dialog/confirm_basic_auth.html
+++ b/dialog/confirm_basic_auth.html
@@ -28,20 +28,23 @@
     <header>
       <h1 id="msg" data-i18n="dialogConfirmBasicAuthHeader"></h1>
     </header>
-    <div id="container">
-      <div id="text" class="force">
+    <div id="container" class="basic_auth">
+      <div id="text" class="basic_auth">
         <p data-i18n="dialogConfirmBasicAuthBody"></p>
         <ul>
-          <li><span data-i18n="dialogConfirmBasicAuthPage"></span> <span id="request-url" class="request-info"></li>
-          <li><span data-i18n="dialogConfirmBasicAuthHost"></span> <span id="host" class="request-info"></li>
-          <li class="hidden" id="realm-part"><span data-i18n="dialogConfirmBasicAuthRealm"></span> <span id="realm" class="request-info"></li>
+          <li><span data-i18n="dialogConfirmBasicAuthPage"></span> <span id="request-url" class="request-info"></span></li>
+          <li><span data-i18n="dialogConfirmBasicAuthHost"></span> <span id="host" class="request-info"></span></li>
+          <li class="hidden" id="realm-part"><span data-i18n="dialogConfirmBasicAuthRealm"></span> <span id="realm" class="request-info"></span></li>
           <li class="hidden warning" id="host-warning"><span data-i18n="dialogConfirmBasicAuthHostWarning" class="request-info"></span> <span id="request-host" class="request-info"></span></li>
-          <li class="hidden warning" id="ssl-warning"><span data-i18n="dialogConfirmBasicAuthSSLWarning" class="request-info"></li>
+          <li class="hidden warning" id="ssl-warning"><span data-i18n="dialogConfirmBasicAuthSSLWarning" class="request-info"></span></li>
         </ul>
       </div>
 
-      <div id="form" class="force">
-        <button type="button" class="accept" id="fill" data-i18n="dialogConfirmBasicAuthFill"></button>
+      <div id="form" class="basic_auth">
+        <div id="passwords">
+
+        </div>
+        <button type="button" class="accept" id="fetch" data-i18n="dialogConfirmBasicAuthFill"></button>
         <button type="button" id="cancel" data-i18n="Cancel"></button>
       </div>
     </div>

--- a/dialog/confirm_basic_auth.html
+++ b/dialog/confirm_basic_auth.html
@@ -42,8 +42,7 @@
 
       <div id="form" class="force">
         <button type="button" class="accept" id="fill" data-i18n="dialogConfirmBasicAuthFill"></button>
-        <button type="button" id="cancel" data-i18n="dialogConfirmBasicAuthSkip"></button>
-        <button type="button" class="cancel" id="realcancel" data-i18n="Cancel"></button>
+        <button type="button" id="cancel" data-i18n="Cancel"></button>
       </div>
     </div>
 

--- a/dialog/confirm_basic_auth.html
+++ b/dialog/confirm_basic_auth.html
@@ -29,17 +29,18 @@
       <h1 id="msg" data-i18n="dialogConfirmBasicAuthHeader"></h1>
     </header>
     <div id="container">
-      <div id="text">
+      <div id="text" class="force">
         <p data-i18n="dialogConfirmBasicAuthBody"></p>
         <ul>
           <li><span data-i18n="dialogConfirmBasicAuthPage"></span> <span id="request-url" class="request-info"></li>
           <li><span data-i18n="dialogConfirmBasicAuthHost"></span> <span id="host" class="request-info"></li>
           <li class="hidden" id="realm-part"><span data-i18n="dialogConfirmBasicAuthRealm"></span> <span id="realm" class="request-info"></li>
-          <li class="hidden warning" id="host-warning"><span data-i18n="dialogConfirmBasicAuthHostWarning"></span> <span id="request-host" class="request-info"></span></li>
+          <li class="hidden warning" id="host-warning"><span data-i18n="dialogConfirmBasicAuthHostWarning" class="request-info"></span> <span id="request-host" class="request-info"></span></li>
+          <li class="hidden warning" id="ssl-warning"><span data-i18n="dialogConfirmBasicAuthSSLWarning" class="request-info"></li>
         </ul>
       </div>
 
-      <div id="form">
+      <div id="form" class="force">
         <button type="button" class="accept" id="fill" data-i18n="dialogConfirmBasicAuthFill"></button>
         <button type="button" id="cancel" data-i18n="dialogConfirmBasicAuthSkip"></button>
         <button type="button" class="cancel" id="realcancel" data-i18n="Cancel"></button>

--- a/dialog/confirm_basic_auth.html
+++ b/dialog/confirm_basic_auth.html
@@ -28,9 +28,10 @@
     <header>
       <h1 id="msg" data-i18n="dialogConfirmBasicAuthHeader"></h1>
     </header>
-    <div id="container" class="basic_auth">
-      <div id="text" class="basic_auth">
-        <p data-i18n="dialogConfirmBasicAuthBody"></p>
+    <div id="container">
+      <div id="text">
+        <p data-i18n="dialogConfirmBasicAuthBody" class="dialogConfirmBasicAuthBody"></p>
+        <p data-i18n="dialogConfirmBasicAuthSelect" class=dialogConfirmBasicAuthSelect></p>
         <ul>
           <li><span data-i18n="dialogConfirmBasicAuthPage"></span> <span id="request-url" class="request-info"></span></li>
           <li><span data-i18n="dialogConfirmBasicAuthHost"></span> <span id="host" class="request-info"></span></li>
@@ -40,7 +41,7 @@
         </ul>
       </div>
 
-      <div id="form" class="basic_auth">
+      <div id="form">
         <div id="passwords">
 
         </div>

--- a/dialog/confirm_basic_auth.html
+++ b/dialog/confirm_basic_auth.html
@@ -1,0 +1,58 @@
+<!--
+  * @copyright Robin Jadoul
+  *
+  * Copyright (C) 2018  Robin Jadoul
+  * This file is part of Keywi.
+  * Keywi is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * Keywi is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+
+  * You should have received a copy of the GNU General Public License
+  * along with Keywi.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title data-i18n="dialogConfirmBasicAuthTitle"></title>
+    <link rel="stylesheet" type="text/css" href="user_input.css">
+    <link rel="stylesheet" type="text/css" href="confirm_basic_auth.css">
+  </head>
+  <body>
+    <header>
+      <h1 id="msg" data-i18n="dialogConfirmBasicAuthHeader"></h1>
+    </header>
+    <div id="container">
+      <div id="text">
+        <p data-i18n="dialogConfirmBasicAuthBody"></p>
+        <ul>
+          <li><span data-i18n="dialogConfirmBasicAuthPage"></span> <span id="request-url" class="request-info"></li>
+          <li><span data-i18n="dialogConfirmBasicAuthHost"></span> <span id="host" class="request-info"></li>
+          <li class="hidden" id="realm-part"><span data-i18n="dialogConfirmBasicAuthRealm"></span> <span id="realm" class="request-info"></li>
+          <li class="hidden warning" id="host-warning"><span data-i18n="dialogConfirmBasicAuthHostWarning"></span> <span id="request-host" class="request-info"></span></li>
+        </ul>
+      </div>
+
+      <div id="form">
+        <button type="button" class="accept" id="fill" data-i18n="dialogConfirmBasicAuthFill"></button>
+        <button type="button" id="cancel" data-i18n="dialogConfirmBasicAuthSkip"></button>
+        <button type="button" class="cancel" id="realcancel" data-i18n="Cancel"></button>
+      </div>
+    </div>
+
+    <footer>
+      <p>Keywi</p>
+    </footer>
+
+
+    <script src="dialog_common.js"></script>
+    <script src="confirm_basic_auth.js"></script>
+  </body>
+</html>
+

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -17,7 +17,21 @@
  * along with Keywi.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+const generateButtonRow = function (name, login) {
+  const div = document.createElement('div');
+  div.classList.add('password-container');
+
+  const button = document.createElement('button');
+  button.classList.add('password-choose-btn');
+  button.innerText = `${login} (${name})`;
+
+  div.appendChild(button);
+
+  return div;
+};
+
 window.addEventListener('DOMContentLoaded', function () {
+  document.getElementById('passwords').hidden = true;
   function show(id) {
     document.getElementById(id).classList.remove('hidden');
   }
@@ -48,8 +62,39 @@ window.addEventListener('DOMContentLoaded', function () {
   });
 });
 
-document.getElementById('fill').onclick = function () {
-  browser.runtime.sendMessage({'type': 'confirm_basic_auth_fill'});
+document.getElementById('fetch').onclick = function () {
+  // browser.runtime.sendMessage({'type': 'confirm_basic_auth_fill'});
+  browser.runtime.sendMessage({'type': 'confirm_basic_auth_fetch'}).then((credentials) => {
+    console.log("DONE!");
+    console.log(credentials);
+    const length = credentials.length;
+    const passwordsEl = document.getElementById('passwords');
+
+    // clear previous entries
+    while (passwordsEl.hasChildNodes()) {
+      passwordsEl.removeChild(passwordsEl.lastChild);
+    }
+
+    for (let i = 0; i < length; i++) {
+      const el = generateButtonRow(credentials[i].Name, credentials[i].Login);
+      el.addEventListener('click', function() {
+        console.log(credentials);
+        browser.runtime.sendMessage({
+          'type': 'confirm_basic_auth_select',
+          'data': {'selected': credentials[i]}
+        });
+      }, false);
+      passwordsEl.appendChild(el);
+    }
+
+    document.getElementById('fetch').hidden = true;
+    document.getElementById('text').hidden = true;
+    document.getElementById('passwords').hidden = false;
+
+  }).catch(error => {
+    console.log(error);
+  });
+
 };
 
 document.getElementById('cancel').onclick = function () {

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -55,3 +55,9 @@ document.getElementById('fill').onclick = function () {
 document.getElementById('cancel').onclick = function () {
   browser.runtime.sendMessage({'type': 'confirm_basic_auth_cancel'});
 };
+
+document.addEventListener('keyup', function (ev) {
+  if (ev.key === 'Accept' || ev.key === 'Execute' || ev.key === 'Enter') {
+    document.getElementById('fill').click();
+  }
+});

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Robin Jadoul
+ * @copyright Tobia De Koninck
  *
  * Copyright (C) 2018  Robin Jadoul
  * This file is part of Keywi.
@@ -65,8 +66,6 @@ window.addEventListener('DOMContentLoaded', function () {
 document.getElementById('fetch').onclick = function () {
   // browser.runtime.sendMessage({'type': 'confirm_basic_auth_fill'});
   browser.runtime.sendMessage({'type': 'confirm_basic_auth_fetch'}).then((credentials) => {
-    console.log("DONE!");
-    console.log(credentials);
     const length = credentials.length;
     const passwordsEl = document.getElementById('passwords');
 
@@ -78,7 +77,6 @@ document.getElementById('fetch').onclick = function () {
     for (let i = 0; i < length; i++) {
       const el = generateButtonRow(credentials[i].Name, credentials[i].Login);
       el.addEventListener('click', function() {
-        console.log(credentials);
         browser.runtime.sendMessage({
           'type': 'confirm_basic_auth_select',
           'data': {'selected': credentials[i]}
@@ -93,9 +91,10 @@ document.getElementById('fetch').onclick = function () {
     document.querySelector('#text ul').hidden = true;
     document.getElementById('passwords').hidden = false;
 
-  }).catch(error => {
-    console.log(error);
-  });
+  }).
+    catch((error) => {
+      console.log(error);
+    });
 
 };
 

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -18,20 +18,31 @@
  */
 
 window.addEventListener('DOMContentLoaded', function () {
+  function show(id) {
+    document.getElementById(id).classList.remove('hidden');
+  }
+  function set(id, val) {
+    document.getElementById(id).innerText = val;
+  }
+
   browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     if (request.type === 'confirm_basic_auth_data') {
+      const url = request.data.url;
       const host = request.data.host;
       const realm = request.data.realm;
       const pageHost = request.data.page_host;
-      document.getElementById('request-url').innerText = request.data.url;
-      document.getElementById('host').innerText = host;
+      set('request-url', url);
+      set('host', host);
       if (realm !== null && realm !== undefined) {
-        document.getElementById('realm').innerText = realm;
-        document.getElementById('realm-part').classList.remove('hidden');
+        set('realm', realm);
+        show('realm-part');
       }
       if (host !== pageHost) {
-        document.getElementById('request-host').innerText = pageHost;
-        document.getElementById('host-warning').classList.remove('hidden');
+        set('request-host', pageHost);
+        show('host-warning');
+      }
+      if (!url.startsWith('https://')) {
+        show('ssl-warning');
       }
     }
   });

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -53,9 +53,5 @@ document.getElementById('fill').onclick = function () {
 };
 
 document.getElementById('cancel').onclick = function () {
-  browser.runtime.sendMessage({'type': 'confirm_basic_auth_manual'});
-};
-
-document.getElementById('realcancel').onclick = function () {
   browser.runtime.sendMessage({'type': 'confirm_basic_auth_cancel'});
 };

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -64,7 +64,6 @@ window.addEventListener('DOMContentLoaded', function () {
 });
 
 document.getElementById('fetch').onclick = function () {
-  // browser.runtime.sendMessage({'type': 'confirm_basic_auth_fill'});
   browser.runtime.sendMessage({'type': 'confirm_basic_auth_fetch'}).then((credentials) => {
     const length = credentials.length;
     const passwordsEl = document.getElementById('passwords');
@@ -104,6 +103,10 @@ document.getElementById('cancel').onclick = function () {
 
 document.addEventListener('keyup', function (ev) {
   if (ev.key === 'Accept' || ev.key === 'Execute' || ev.key === 'Enter') {
-    document.getElementById('fetch').click();
+    if (!document.getElementById('fetch').hidden) {
+      document.getElementById('fetch').click();
+    } else if (document.getElementById('passwords').children.length === 1) {
+      document.getElementById('passwords').children[0].click();
+    }
   }
 });

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -105,6 +105,6 @@ document.getElementById('cancel').onclick = function () {
 
 document.addEventListener('keyup', function (ev) {
   if (ev.key === 'Accept' || ev.key === 'Execute' || ev.key === 'Enter') {
-    document.getElementById('fill').click();
+    document.getElementById('fetch').click();
   }
 });

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -88,7 +88,9 @@ document.getElementById('fetch').onclick = function () {
     }
 
     document.getElementById('fetch').hidden = true;
-    document.getElementById('text').hidden = true;
+    document.getElementsByClassName('dialogConfirmBasicAuthBody')[0].hidden = true;
+    document.getElementsByClassName('dialogConfirmBasicAuthSelect')[0].hidden = false;
+    document.querySelector('#text ul').hidden = true;
     document.getElementById('passwords').hidden = false;
 
   }).catch(error => {

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -1,0 +1,50 @@
+/**
+ * @copyright Robin Jadoul
+ *
+ * Copyright (C) 2018  Robin Jadoul
+ * This file is part of Keywi.
+ * Keywi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Keywi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Keywi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+window.addEventListener('DOMContentLoaded', function () {
+  browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+    if (request.type === 'confirm_basic_auth_data') {
+      const host = request.data.host;
+      const realm = request.data.realm;
+      const pageHost = request.data.page_host;
+      document.getElementById('request-url').innerText = request.data.url;
+      document.getElementById('host').innerText = host;
+      if (realm !== null && realm !== undefined) {
+        document.getElementById('realm').innerText = realm;
+        document.getElementById('realm-part').classList.remove('hidden');
+      }
+      if (host !== pageHost) {
+        document.getElementById('request-host').innerText = pageHost;
+        document.getElementById('host-warning').classList.remove('hidden');
+      }
+    }
+  });
+});
+
+document.getElementById('fill').onclick = function () {
+  browser.runtime.sendMessage({'type': 'confirm_basic_auth_fill'});
+};
+
+document.getElementById('cancel').onclick = function () {
+  browser.runtime.sendMessage({'type': 'confirm_basic_auth_manual'});
+};
+
+document.getElementById('realcancel').onclick = function () {
+  browser.runtime.sendMessage({'type': 'confirm_basic_auth_cancel'});
+};

--- a/dialog/confirm_basic_auth.js
+++ b/dialog/confirm_basic_auth.js
@@ -48,7 +48,7 @@ window.addEventListener('DOMContentLoaded', function () {
       const pageHost = request.data.page_host;
       set('request-url', url);
       set('host', host);
-      if (realm !== null && realm !== undefined) {
+      if (realm !== null && typeof realm !== 'undefined') {
         set('realm', realm);
         show('realm-part');
       }

--- a/dialog/dialog_common.js
+++ b/dialog/dialog_common.js
@@ -40,6 +40,5 @@ window.addEventListener('DOMContentLoaded', function () {
 document.addEventListener('keyup', function (ev) {
   if (ev.key === 'Escape' || ev.key === 'Cancel') {
     document.getElementById('cancel').click();
-    document.getElementById('cancel').click();
   }
 });

--- a/dialog/select_multiple_passwords.css
+++ b/dialog/select_multiple_passwords.css
@@ -22,28 +22,4 @@
     height: auto !important;
 }
 
-#form {
-    height: 320px !important;
-}
 
-.password-choose-btn {
-    color: #fff;
-    background-color: #5cb85c;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    width: 340px;
-    padding: 5px;
-    margin-top: 5px;
-    margin-bottom: 5px;
-    box-sizing: border-box;
-}
-
-#passwords {
-    height: 260px;
-    overflow-y: auto;
-}
-
-#cancel-container {
-    height: 60px;
-    padding-top: 10px;
-}

--- a/dialog/user_input.css
+++ b/dialog/user_input.css
@@ -81,6 +81,8 @@ footer p {
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     flex: none;
+    position: relative;
+    min-height: 370px;
 }
 
 .accept, .cancel, #pass, #pass1, #pass2, #submit, #cancel {
@@ -113,20 +115,44 @@ footer p {
 }
 
 #text, #form {
-    height: 185px;
     box-sizing: border-box;
     width: 340px;
-    margin: 0 auto;
 }
 
-#text.basic_auth, #form.basic_auth {
-  height: auto;
+#text {
+  margin: auto auto;
 }
 
-#container.basic_auth {
-  min-height: 371px!important; /* make dialogs for basic_auth at least the same height*/
+#form {
+  position: absolute;
+  bottom: 15px;
+  left: 0;
+  right: 0;
+  margin: auto auto;
 }
 
 button {
     cursor:pointer;
+}
+
+.password-choose-btn {
+  color: #fff;
+  background-color: #5cb85c;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  width: 340px;
+  padding: 5px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  box-sizing: border-box;
+}
+
+#passwords {
+  height: 190px;
+  overflow-y: auto;
+}
+
+#cancel-container {
+  height: 60px;
+  padding-top: 10px;
 }

--- a/dialog/user_input.css
+++ b/dialog/user_input.css
@@ -119,8 +119,12 @@ footer p {
     margin: 0 auto;
 }
 
-#text.force {
+#text.basic_auth, #form.basic_auth {
   height: auto;
+}
+
+#container.basic_auth {
+  min-height: 371px!important; /* make dialogs for basic_auth at least the same height*/
 }
 
 button {

--- a/dialog/user_input.css
+++ b/dialog/user_input.css
@@ -119,6 +119,10 @@ footer p {
     margin: 0 auto;
 }
 
+#text.force, #form.force {
+  height: auto;
+}
+
 button {
     cursor:pointer;
 }

--- a/dialog/user_input.css
+++ b/dialog/user_input.css
@@ -119,7 +119,7 @@ footer p {
     margin: 0 auto;
 }
 
-#text.force, #form.force {
+#text.force {
   height: auto;
 }
 

--- a/dialog/user_input.css
+++ b/dialog/user_input.css
@@ -83,7 +83,7 @@ footer p {
     flex: none;
 }
 
-#pass, #pass1, #pass2, #submit, #cancel {
+.accept, .cancel, #pass, #pass1, #pass2, #submit, #cancel {
     width: 340px;
     padding-top: 5px;
     padding-bottom: 5px;
@@ -97,7 +97,7 @@ footer p {
     border-radius: 4px;
 }
 
-#submit {
+.accept, #submit {
     color: #fff;
     background-color: #5cb85c;
     border: 1px solid transparent;
@@ -105,7 +105,7 @@ footer p {
     cursor:pointer;
 }
 
-#cancel {
+.cancel, #cancel {
     color: #fff;
     background-color: #d9534f;
     border-radius: 4px;

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
       "background/contextmenu.js",
       "background/commands.js",
       "background/request.js",
-      "background/init.js"
+      "background/init.js",
+      "background/basicauth.js"
     ]
   },
   "permissions": [
@@ -30,7 +31,9 @@
     "contextMenus",
     "tabs",
     "storage",
-    "notifications"
+    "notifications",
+    "webRequest",
+    "webRequestBlocking"
   ],
   "content_scripts": [
     {


### PR DESCRIPTION
Status:
- [x] Offer a choice of passwords if there's more than one (that came automatically, gotta love reuse :wink:)
- [x] Offer the user a dialog where they can choose to:
   + Use keywi - automatically triggered on <kbd>Enter</kbd> - can we somehow try to check if there's at least one password available when the DB is unlocked (that way, we can prevent annoying the user when the pass is not stored in KP)?
    + Cancel - automatically triggered on <kbd>Esc</kbd> or closing the window - This lets the browser do its thing (or possibly another addon), usually resulting in the default FF popup that asks for username and password
- ~Notify the user if this is a retry of filling the password (i.e. the first time failed) - in the dialog~ not needed for now, because the repeat of the dialog should give enough information
- [x] Warn on non-https challengers
- [x] The current tab url is not up to date when trying to check if the challenger host is the same host as the current page
- [x] Don't forget the port when looking at hosts
- ~Send the realm along to KP? (https://github.com/pfn/keepasshttp/blob/425d4cda428e7f0ba49bcbeba3269fed5c9822b4/KeePassHttp/Protocol.cs#L123)~ Only useful when entry created by KeepassHTTP, would give worse results actually.
- [x] translation of the dialog (waiting for completion and approval of other features first)
- [x] test origin URL on FF 54 + bump version needed

The linting errors about the `clean` function are most probably unavoidable; the ternary one should be fixable, but I feel it's not that bad here; and the `undefined` one seems out of place, since I consider it a proper check there.