### PR TITLE
Fix autofill after unlock

### DIFF
--- a/background/keepass.js
+++ b/background/keepass.js
@@ -326,7 +326,9 @@ Keepass.associate = function () {
      * If it was done the other way around, then if setting up the secure storage would fail
      * the association request would still be done, but the result couldn't be saved
      */
-    return Keepass._ss.reInitialize().then(Keepass.associate);
+    return Keepass._ss.reInitialize().then(function () {
+      return Keepass.associate();
+    });
   }
 
   // test if we are already associated and it's working


### PR DESCRIPTION
## Steps to reproduce

 1. make sure Keepass(xc) is unlocked and that the Secure Storage is locked (e.g. reload the addon in about:debugging)
 2. Try to fill credentials in a website 
 4. unlock the secure storage

## Expected behaviour
 4. The credentials should be filled

## Actual behaviour
 4. The credentials aren't filled. After filling for a second time, the credentials are correctly filled.

This was introduced with commit e9f1d6654894bfbd90c0055fe4ed0fc630eb4a2b which was introduced in v1.3.0/v1.3.1 (recently released).




